### PR TITLE
Change location of Modernizr script on Demo page

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="week-polyfill.css" />
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.1/jquery-ui.min.js"></script>
-    <script type="text/javascript" src="http://www.modernizr.com/downloads/modernizr-latest.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
     <script type="text/javascript" src="week-polyfill.js"></script>
     <script type="text/javascript">
 //<![CDATA[


### PR DESCRIPTION
Change to CDN at https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js since the previous URL was giving a blank script.

Fixes #1
